### PR TITLE
Refactor admin users table

### DIFF
--- a/zen-cat-frontend/ZenCat-Front-Admin/src/components/users/columns.tsx
+++ b/zen-cat-frontend/ZenCat-Front-Admin/src/components/users/columns.tsx
@@ -1,0 +1,110 @@
+import { ColumnDef } from '@tanstack/react-table';
+import { User } from '@/types/user';
+import { Button } from '@/components/ui/button';
+import { Checkbox } from '@/components/ui/checkbox';
+import { ArrowUpDown, MoreHorizontal, Trash } from 'lucide-react';
+
+interface GetUserColumnsProps {
+  onEdit: (user: User) => void;
+  onDelete: (user: User) => void;
+  onViewMemberships: (user: User) => void;
+}
+
+export function getUserColumns({ onEdit, onDelete, onViewMemberships }: GetUserColumnsProps): ColumnDef<User>[] {
+  return [
+    {
+      id: 'select',
+      header: ({ table }) => (
+        <Checkbox
+          checked={table.getIsAllPageRowsSelected() || (table.getIsSomePageRowsSelected() && 'indeterminate')}
+          onCheckedChange={(v) => table.toggleAllPageRowsSelected(!!v)}
+          aria-label="Select all"
+        />
+      ),
+      cell: ({ row }) => (
+        <Checkbox
+          checked={row.getIsSelected()}
+          onCheckedChange={(v) => row.toggleSelected(!!v)}
+          aria-label="Select row"
+        />
+      ),
+      enableSorting: false,
+      enableHiding: false,
+    },
+    {
+      accessorKey: 'name',
+      header: ({ column }) => (
+        <Button variant="ghost" onClick={() => column.toggleSorting(column.getIsSorted() === 'asc')}>
+          Nombres <ArrowUpDown className="ml-2 h-4 w-4" />
+        </Button>
+      ),
+      cell: ({ row }) => <div>{row.getValue('name')}</div>,
+    },
+    {
+      accessorKey: 'address',
+      header: 'Dirección',
+      cell: ({ row }) => <div>{row.getValue('address') || '-'}</div>,
+    },
+    {
+      accessorKey: 'district',
+      header: 'Distrito',
+      cell: ({ row }) => <div>{row.getValue('district') || '-'}</div>,
+    },
+    {
+      accessorKey: 'phone',
+      header: 'Teléfono',
+      cell: ({ row }) => <div>{row.getValue('phone') || '-'}</div>,
+    },
+    {
+      accessorKey: 'email',
+      header: ({ column }) => (
+        <Button variant="ghost" onClick={() => column.toggleSorting(column.getIsSorted() === 'asc')}>
+          Email <ArrowUpDown className="ml-2 h-4 w-4" />
+        </Button>
+      ),
+    },
+    {
+      id: 'memberships',
+      header: 'Membresías',
+      cell: ({ row }) => {
+        const user = row.original;
+        return (
+          <Button
+            className="h-9 px-4 bg-white border border-neutral-300 text-black rounded-lg flex items-center gap-2 shadow-sm hover:bg-black hover:text-white hover:border-black hover:shadow-md transition-all duration-200"
+            onClick={() => onViewMemberships(user)}
+          >
+            Membresías ...
+          </Button>
+        );
+      },
+    },
+    {
+      id: 'actions',
+      cell: ({ row }) => {
+        const user = row.original;
+        return (
+          <div className="flex items-center space-x-2">
+            <Button
+              className="h-8 w-8 p-0 bg-white text-black border border-black rounded-full flex items-center justify-center hover:bg-red-100 hover:shadow-md transition-all duration-200"
+              onClick={(e) => {
+                e.stopPropagation();
+                onEdit(user);
+              }}
+            >
+              <MoreHorizontal className="h-4 w-4" />
+            </Button>
+            <Button
+              className="h-8 w-8 p-0 bg-white text-black border border-black rounded-full flex items-center justify-center hover:bg-red-100 hover:shadow-md transition-all duration-200"
+              onClick={(e) => {
+                e.stopPropagation();
+                onDelete(user);
+              }}
+            >
+              <Trash className="h-4 w-4" />
+            </Button>
+          </div>
+        );
+      },
+    },
+  ];
+}

--- a/zen-cat-frontend/ZenCat-Front-Admin/src/components/users/table.tsx
+++ b/zen-cat-frontend/ZenCat-Front-Admin/src/components/users/table.tsx
@@ -1,0 +1,70 @@
+'use client';
+import { useReactTable, getCoreRowModel, getFilteredRowModel, getSortedRowModel, getPaginationRowModel } from '@tanstack/react-table';
+import { useDataTable } from '@/hooks/use-data-table';
+import { DataTable } from '@/components/common/data-table/data-table';
+import { DataTableToolbar } from '@/components/common/data-table/data-table-toolbar';
+import { DataTablePagination } from '@/components/common/data-table/data-table-pagination';
+import { User } from '@/types/user';
+import { getUserColumns } from './columns';
+
+interface UsersTableProps {
+  data: User[];
+  onEdit: (user: User) => void;
+  onDelete: (user: User) => void;
+  onViewMemberships: (user: User) => void;
+}
+
+export function UsersTable({ data, onEdit, onDelete, onViewMemberships }: UsersTableProps) {
+  const {
+    sorting, setSorting,
+    columnFilters, setColumnFilters,
+    columnVisibility, setColumnVisibility,
+    rowSelection, setRowSelection,
+    globalFilter, setGlobalFilter,
+    pagination, setPagination,
+  } = useDataTable();
+
+  const columns = getUserColumns({ onEdit, onDelete, onViewMemberships });
+
+  const table = useReactTable({
+    data,
+    columns,
+    state: {
+      sorting,
+      columnFilters,
+      columnVisibility,
+      rowSelection,
+      globalFilter,
+      pagination,
+    },
+    onSortingChange: setSorting,
+    onColumnFiltersChange: setColumnFilters,
+    onColumnVisibilityChange: setColumnVisibility,
+    onRowSelectionChange: setRowSelection,
+    onGlobalFilterChange: setGlobalFilter,
+    onPaginationChange: setPagination,
+    getCoreRowModel: getCoreRowModel(),
+    getFilteredRowModel: getFilteredRowModel(),
+    getSortedRowModel: getSortedRowModel(),
+    getPaginationRowModel: getPaginationRowModel(),
+    enableRowSelection: true,
+  });
+
+  return (
+    <div className="-mx-4 flex-1 overflow-auto px-4 py-2">
+      <DataTableToolbar
+        table={table}
+        filterPlaceholder="Buscar usuarios..."
+        showSortButton
+        showFilterButton
+        showExportButton
+        onFilterClick={() => console.log('Filtrar')}
+        onExportClick={() => console.log('Exportar')}
+      />
+      <div className="flex-1 overflow-hidden rounded-md border">
+        <DataTable table={table} columns={columns} />
+      </div>
+      <DataTablePagination table={table} />
+    </div>
+  );
+}

--- a/zen-cat-frontend/ZenCat-Front-Admin/src/hooks/use-data-table.ts
+++ b/zen-cat-frontend/ZenCat-Front-Admin/src/hooks/use-data-table.ts
@@ -1,0 +1,31 @@
+import { useState } from 'react';
+import {
+  SortingState,
+  ColumnFiltersState,
+  VisibilityState,
+  PaginationState,
+} from '@tanstack/react-table';
+
+export function useDataTable() {
+  const [sorting, setSorting] = useState<SortingState>([]);
+  const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([]);
+  const [columnVisibility, setColumnVisibility] = useState<VisibilityState>({});
+  const [rowSelection, setRowSelection] = useState({});
+  const [globalFilter, setGlobalFilter] = useState('');
+  const [pagination, setPagination] = useState<PaginationState>({ pageIndex: 0, pageSize: 10 });
+
+  return {
+    sorting,
+    setSorting,
+    columnFilters,
+    setColumnFilters,
+    columnVisibility,
+    setColumnVisibility,
+    rowSelection,
+    setRowSelection,
+    globalFilter,
+    setGlobalFilter,
+    pagination,
+    setPagination,
+  };
+}


### PR DESCRIPTION
## Summary
- add `useDataTable` hook for common table state
- modularize users table with new columns and table components
- refactor `/usuarios` route to use the new table component

## Testing
- `bun run lint` *(fails: `prettierConfig is not defined`)*
- `bun run build` *(fails: TypeScript errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_684116f9941c83219c777c0440b5b238